### PR TITLE
feat: add paginated editor with page breaks and PDF export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,8 @@
         "@tiptap/react": "^3.0.9",
         "@tiptap/starter-kit": "^3.0.9",
         "framer-motion": "^12.23.12",
+        "html2canvas": "^1.4.1",
+        "pdf-lib": "^1.17.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "zustand": "^5.0.7"
@@ -1132,6 +1134,24 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@pdf-lib/standard-fonts": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/standard-fonts/-/standard-fonts-1.0.0.tgz",
+      "integrity": "sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.6"
+      }
+    },
+    "node_modules/@pdf-lib/upng": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/upng/-/upng-1.0.1.tgz",
+      "integrity": "sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.10"
       }
     },
     "node_modules/@radix-ui/primitive": {
@@ -2753,7 +2773,7 @@
       "version": "19.1.9",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.9.tgz",
       "integrity": "sha512-WmdoynAX8Stew/36uTSVMcLJJ1KRh6L3IZRx1PZ7qJtBqT3dYTgyDTx8H1qoRghErydW7xw9mSJ3wS//tCRpFA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -2763,7 +2783,7 @@
       "version": "19.1.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.7.tgz",
       "integrity": "sha512-i5ZzwYpqjmrKenzkoLM2Ibzt6mAsM7pxB6BCIouEVVmgiqaMj1TjaK7hnA36hbW5aZv20kx7Lw6hWzPWg0Rurw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
@@ -3186,6 +3206,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -3356,11 +3385,20 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -3943,6 +3981,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -4465,6 +4516,19 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -4638,6 +4702,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -4671,6 +4741,24 @@
         "node": ">=8"
       }
     },
+    "node_modules/pdf-lib": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/pdf-lib/-/pdf-lib-1.17.1.tgz",
+      "integrity": "sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@pdf-lib/standard-fonts": "^1.0.0",
+        "@pdf-lib/upng": "^1.0.1",
+        "pako": "^1.0.11",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/pdf-lib/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -4679,13 +4767,13 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8.6"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -5283,6 +5371,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.14",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
@@ -5298,19 +5395,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
-      }
-    },
-    "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/to-regex-range": {
@@ -5495,6 +5579,15 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
+      }
+    },
     "node_modules/vite": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.0.6.tgz",
@@ -5568,19 +5661,6 @@
         "yaml": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/w3c-keyname": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "@tiptap/react": "^3.0.9",
     "@tiptap/starter-kit": "^3.0.9",
     "framer-motion": "^12.23.12",
+    "html2canvas": "^1.4.1",
+    "pdf-lib": "^1.17.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "zustand": "^5.0.7"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,34 +1,11 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
 import './App.css'
+import { Editor } from './editor/Editor'
 
 function App() {
-  const [count, setCount] = useState(0)
-
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+    <div className="p-4">
+      <Editor />
+    </div>
   )
 }
 

--- a/src/editor/Editor.tsx
+++ b/src/editor/Editor.tsx
@@ -1,0 +1,65 @@
+import { useRef } from 'react'
+import { useEditor, EditorContent } from '@tiptap/react'
+import StarterKit from '@tiptap/starter-kit'
+import PageBreak from './extensions/PageBreak'
+import { usePagination } from './usePagination'
+import { PageHeader } from './components/PageHeader'
+import { PageFooter } from './components/PageFooter'
+import { exportPdf } from './exportPdf'
+
+export const Editor = () => {
+  const editor = useEditor({
+    extensions: [StarterKit, PageBreak],
+    content: '<p></p>',
+  })
+
+  const pages = usePagination(editor?.getHTML() || '')
+  const previewRef = useRef<HTMLDivElement>(null)
+
+  const handleExport = async () => {
+    const nodes = Array.from(
+      previewRef.current?.querySelectorAll('.page') || [],
+    ) as HTMLElement[]
+    await exportPdf(nodes)
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex gap-2">
+        <button
+          className="px-2 py-1 bg-gray-200 rounded"
+          onClick={() => editor?.chain().focus().setPageBreak().run()}
+        >
+          Page Break
+        </button>
+        <button
+          className="px-2 py-1 bg-blue-500 text-white rounded"
+          onClick={handleExport}
+        >
+          Export PDF
+        </button>
+      </div>
+      <EditorContent
+        editor={editor}
+        className="border min-h-[300px] p-4"
+      />
+      <div ref={previewRef} className="preview">
+        {pages.map((html, i) => (
+          <div
+            key={i}
+            className="page w-[794px] h-[1122px] mx-auto mb-4 bg-white shadow flex flex-col"
+          >
+            <PageHeader title="Document" />
+            <div
+              className="flex-1 p-8 prose"
+              dangerouslySetInnerHTML={{ __html: html }}
+            />
+            <PageFooter pageNumber={i + 1} />
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export default Editor

--- a/src/editor/components/PageFooter.tsx
+++ b/src/editor/components/PageFooter.tsx
@@ -1,0 +1,16 @@
+import type { FC } from 'react'
+
+interface PageFooterProps {
+  pageNumber: number
+}
+
+/** Basic footer that displays the current page number */
+export const PageFooter: FC<PageFooterProps> = ({ pageNumber }) => {
+  return (
+    <footer className="page-footer text-center py-2 border-t border-gray-300 text-sm text-gray-600">
+      Page {pageNumber}
+    </footer>
+  )
+}
+
+export default PageFooter

--- a/src/editor/components/PageHeader.tsx
+++ b/src/editor/components/PageHeader.tsx
@@ -1,0 +1,16 @@
+import type { FC } from 'react'
+
+interface PageHeaderProps {
+  title?: string
+}
+
+/** Basic page header shown at the top of each page */
+export const PageHeader: FC<PageHeaderProps> = ({ title }) => {
+  return (
+    <header className="page-header text-center py-2 border-b border-gray-300 text-sm text-gray-600">
+      {title || ''}
+    </header>
+  )
+}
+
+export default PageHeader

--- a/src/editor/exportPdf.ts
+++ b/src/editor/exportPdf.ts
@@ -1,0 +1,36 @@
+import { PDFDocument } from 'pdf-lib'
+import html2canvas from 'html2canvas'
+
+/**
+ * Export a list of page elements to a PDF file.
+ * Each page element is converted to an image and embedded in the PDF
+ * preserving the pagination from the editor.
+ */
+export async function exportPdf(pages: HTMLElement[]) {
+  const pdfDoc = await PDFDocument.create()
+
+  for (const page of pages) {
+    const canvas = await html2canvas(page)
+    const pngData = canvas.toDataURL('image/png')
+    const pngImage = await pdfDoc.embedPng(pngData)
+    const { width, height } = canvas
+    const pdfPage = pdfDoc.addPage([width, height])
+    pdfPage.drawImage(pngImage, {
+      x: 0,
+      y: 0,
+      width,
+      height,
+    })
+  }
+
+  const pdfBytes = await pdfDoc.save()
+  const blob = new Blob([pdfBytes], { type: 'application/pdf' })
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement('a')
+  link.href = url
+  link.download = 'document.pdf'
+  link.click()
+  URL.revokeObjectURL(url)
+}
+
+export default exportPdf

--- a/src/editor/extensions/PageBreak.ts
+++ b/src/editor/extensions/PageBreak.ts
@@ -1,0 +1,33 @@
+import { Node } from '@tiptap/core'
+
+/**
+ * PageBreak is a simple block level atom that represents a manual page break.
+ * It renders a div with a data attribute that can be detected by the pagination engine
+ * and styled via CSS.
+ */
+export const PageBreak = Node.create({
+  name: 'pageBreak',
+  group: 'block',
+  atom: true,
+  selectable: true,
+  addCommands() {
+    return {
+      setPageBreak:
+        () =>
+        ({ commands }) =>
+          commands.insertContent({ type: this.name }),
+    }
+  },
+  parseHTML() {
+    return [
+      {
+        tag: 'div[data-type="page-break"]',
+      },
+    ]
+  },
+  renderHTML() {
+    return ['div', { 'data-type': 'page-break', class: 'page-break' }]
+  },
+})
+
+export default PageBreak

--- a/src/editor/usePagination.ts
+++ b/src/editor/usePagination.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * Very small pagination helper that splits raw HTML by the page break node.
+ * A more sophisticated implementation could additionally measure content height
+ * and insert automatic breaks based on page size.
+ */
+export function usePagination(html: string) {
+  const [pages, setPages] = useState<string[]>([])
+
+  useEffect(() => {
+    const parts = html.split(/<div data-type="page-break"[^>]*><\/div>/g)
+    setPages(parts)
+  }, [html])
+
+  return pages
+}
+
+export default usePagination

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,12 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+.page {
+  background: white;
+}
+
+.page-break {
+  border-top: 2px dashed #bbb;
+  margin: 1rem 0;
+}


### PR DESCRIPTION
## Summary
- add PageBreak tiptap extension and pagination hook
- render pages with headers, footers, and export to PDF
- wire up editor preview and basic styles

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688def95d1c48324ba8016e10f7ec794