### PR TITLE
feat: add clause outline and templates sidebar

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import { Editor } from './editor/Editor'
 
 function App() {
   return (
-    <div className="p-4">
+    <div className="p-4 h-screen">
       <Editor />
     </div>
   )

--- a/src/editor/Editor.tsx
+++ b/src/editor/Editor.tsx
@@ -5,6 +5,8 @@ import PageBreak from './extensions/PageBreak'
 import { usePagination } from './usePagination'
 import { PageHeader } from './components/PageHeader'
 import { PageFooter } from './components/PageFooter'
+import { OutlinePanel } from './components/OutlinePanel'
+import { TemplateSidebar } from './components/TemplateSidebar'
 import { exportPdf } from './exportPdf'
 
 export const Editor = () => {
@@ -24,40 +26,44 @@ export const Editor = () => {
   }
 
   return (
-    <div className="space-y-4">
-      <div className="flex gap-2">
-        <button
-          className="px-2 py-1 bg-gray-200 rounded"
-          onClick={() => editor?.chain().focus().setPageBreak().run()}
-        >
-          Page Break
-        </button>
-        <button
-          className="px-2 py-1 bg-blue-500 text-white rounded"
-          onClick={handleExport}
-        >
-          Export PDF
-        </button>
-      </div>
-      <EditorContent
-        editor={editor}
-        className="border min-h-[300px] p-4"
-      />
-      <div ref={previewRef} className="preview">
-        {pages.map((html, i) => (
-          <div
-            key={i}
-            className="page w-[794px] h-[1122px] mx-auto mb-4 bg-white shadow flex flex-col"
+    <div className="flex h-screen">
+      <OutlinePanel editor={editor} />
+      <div className="flex-1 space-y-4 p-4 overflow-y-auto">
+        <div className="flex gap-2">
+          <button
+            className="px-2 py-1 bg-gray-200 rounded"
+            onClick={() => (editor?.chain() as any).focus().setPageBreak().run()}
           >
-            <PageHeader title="Document" />
+            Page Break
+          </button>
+          <button
+            className="px-2 py-1 bg-blue-500 text-white rounded"
+            onClick={handleExport}
+          >
+            Export PDF
+          </button>
+        </div>
+        <EditorContent
+          editor={editor}
+          className="border min-h-[300px] p-4"
+        />
+        <div ref={previewRef} className="preview">
+          {pages.map((html, i) => (
             <div
-              className="flex-1 p-8 prose"
-              dangerouslySetInnerHTML={{ __html: html }}
-            />
-            <PageFooter pageNumber={i + 1} />
-          </div>
-        ))}
+              key={i}
+              className="page w-[794px] h-[1122px] mx-auto mb-4 bg-white shadow flex flex-col"
+            >
+              <PageHeader title="Document" />
+              <div
+                className="flex-1 p-8 prose"
+                dangerouslySetInnerHTML={{ __html: html }}
+              />
+              <PageFooter pageNumber={i + 1} />
+            </div>
+          ))}
+        </div>
       </div>
+      <TemplateSidebar editor={editor} />
     </div>
   )
 }

--- a/src/editor/components/OutlinePanel.tsx
+++ b/src/editor/components/OutlinePanel.tsx
@@ -1,0 +1,120 @@
+import { Editor } from '@tiptap/react'
+import { useEffect, useState } from 'react'
+import { Slice } from '@tiptap/pm/model'
+
+interface OutlineItem {
+  id: string
+  level: number
+  text: string
+  pos: number
+}
+
+export const OutlinePanel = ({ editor }: { editor: Editor | null }) => {
+  const [items, setItems] = useState<OutlineItem[]>([])
+  const [collapsed, setCollapsed] = useState<Set<number>>(new Set())
+
+  useEffect(() => {
+    if (!editor) return
+
+    const generate = () => {
+      const headings: OutlineItem[] = []
+      editor.state.doc.descendants((node, pos) => {
+        if (node.type.name === 'heading' && [1, 2, 3].includes(node.attrs.level)) {
+          const id = `heading-${pos}`
+          const dom = editor.view.nodeDOM(pos) as HTMLElement | null
+          if (dom) dom.id = id
+          headings.push({
+            id,
+            level: node.attrs.level,
+            text: node.textContent,
+            pos,
+          })
+        }
+      })
+      setItems(headings)
+    }
+
+    generate()
+    editor.on('update', generate)
+    return () => {
+      editor.off('update', generate)
+    }
+  }, [editor])
+
+  const navigate = (id: string) => {
+    const el = document.getElementById(id)
+    el?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+  }
+
+  const toggleCollapse = (pos: number) => {
+    if (!editor) return
+    const dom = editor.view.nodeDOM(pos) as HTMLElement | null
+    if (!dom) return
+    const newSet = new Set(collapsed)
+    let sib = dom.nextElementSibling as HTMLElement | null
+    while (sib && !/^H[1-3]$/.test(sib.tagName)) {
+      sib.classList.toggle('hidden')
+      sib = sib.nextElementSibling as HTMLElement | null
+    }
+    if (newSet.has(pos)) newSet.delete(pos)
+    else newSet.add(pos)
+    setCollapsed(newSet)
+  }
+
+  const moveUp = (index: number) => {
+    if (!editor || index === 0) return
+    const { state, view } = editor
+    const pos0 = items[index - 1].pos
+    const pos1 = items[index].pos
+    const pos2 = items[index + 1]?.pos ?? state.doc.content.size
+    const prev = state.doc.slice(pos0, pos1)
+    const current = state.doc.slice(pos1, pos2)
+    const slice = new Slice(current.content.append(prev.content), 0, 0)
+    const tr = state.tr.replaceRange(pos0, pos2, slice)
+    view.dispatch(tr)
+  }
+
+  const moveDown = (index: number) => {
+    if (!editor || index === items.length - 1) return
+    const { state, view } = editor
+    const pos1 = items[index].pos
+    const pos2 = items[index + 1].pos
+    const pos3 = items[index + 2]?.pos ?? state.doc.content.size
+    const current = state.doc.slice(pos1, pos2)
+    const next = state.doc.slice(pos2, pos3)
+    const slice = new Slice(next.content.append(current.content), 0, 0)
+    const tr = state.tr.replaceRange(pos1, pos3, slice)
+    view.dispatch(tr)
+  }
+
+  return (
+    <div className="w-60 border-r p-2 space-y-1 overflow-y-auto">
+      {items.map((item, i) => (
+        <div key={item.id} className="flex items-center gap-1">
+          <button
+            onClick={() => navigate(item.id)}
+            className="flex-1 text-left truncate"
+            style={{ paddingLeft: (item.level - 1) * 8 }}
+          >
+            {item.text || 'Untitled'}
+          </button>
+          <button onClick={() => toggleCollapse(item.pos)} className="px-1">
+            {collapsed.has(item.pos) ? '+' : '-'}
+          </button>
+          <button disabled={i === 0} onClick={() => moveUp(i)} className="px-1">
+            ↑
+          </button>
+          <button
+            disabled={i === items.length - 1}
+            onClick={() => moveDown(i)}
+            className="px-1"
+          >
+            ↓
+          </button>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export default OutlinePanel

--- a/src/editor/components/TemplateSidebar.tsx
+++ b/src/editor/components/TemplateSidebar.tsx
@@ -1,0 +1,37 @@
+import { Editor } from '@tiptap/react'
+
+const templates = [
+  {
+    name: 'NDA Clause',
+    content:
+      '<h2>Confidentiality</h2><p>The parties agree to keep all confidential information secret and not disclose it to any third party without prior written consent.</p>',
+  },
+  {
+    name: 'Termination',
+    content:
+      '<h2>Termination</h2><p>Either party may terminate this agreement with thirty (30) days written notice to the other party.</p>',
+  },
+  {
+    name: 'Governing Law',
+    content:
+      '<h2>Governing Law</h2><p>This agreement shall be governed by and construed in accordance with the laws of the applicable jurisdiction.</p>',
+  },
+]
+
+export const TemplateSidebar = ({ editor }: { editor: Editor | null }) => {
+  return (
+    <div className="w-60 border-l p-2 space-y-2 overflow-y-auto">
+      {templates.map((t) => (
+        <button
+          key={t.name}
+          className="w-full text-left border p-2 rounded hover:bg-gray-50"
+          onClick={() => editor?.commands.insertContent(t.content)}
+        >
+          {t.name}
+        </button>
+      ))}
+    </div>
+  )
+}
+
+export default TemplateSidebar

--- a/src/editor/extensions/PageBreak.ts
+++ b/src/editor/extensions/PageBreak.ts
@@ -14,9 +14,9 @@ export const PageBreak = Node.create({
     return {
       setPageBreak:
         () =>
-        ({ commands }) =>
+        ({ commands }: any) =>
           commands.insertContent({ type: this.name }),
-    }
+    } as any
   },
   parseHTML() {
     return [


### PR DESCRIPTION
## Summary
- add outline panel with navigation, collapsing, and section reordering
- add clause templates sidebar for quick insertion
- integrate side panels into editor layout

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688e0295d880832484285ef45997a55b