### PR TITLE
feat: add interactive template sidebar styling

### DIFF
--- a/src/editor/components/TemplateSidebar.tsx
+++ b/src/editor/components/TemplateSidebar.tsx
@@ -1,4 +1,5 @@
 import { Editor } from '@tiptap/react'
+import { useState } from 'react'
 
 const templates = [
   {
@@ -19,17 +20,28 @@ const templates = [
 ]
 
 export const TemplateSidebar = ({ editor }: { editor: Editor | null }) => {
+  const [active, setActive] = useState<string | null>(null)
+
   return (
     <div className="w-60 border-l p-2 space-y-2 overflow-y-auto">
-      {templates.map((t) => (
-        <button
-          key={t.name}
-          className="w-full text-left border p-2 rounded hover:bg-gray-50"
-          onClick={() => editor?.commands.insertContent(t.content)}
-        >
-          {t.name}
-        </button>
-      ))}
+      {templates.map((t) => {
+        const isActive = active === t.name
+
+        return (
+          <button
+            key={t.name}
+            className={`w-full text-left border p-2 rounded transition-colors ${
+              isActive ? 'bg-gray-200' : 'bg-white hover:bg-gray-50'
+            }`}
+            onClick={() => {
+              editor?.commands.insertContent(t.content)
+              setActive(t.name)
+            }}
+          >
+            {t.name}
+          </button>
+        )
+      })}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add stateful styling to template sidebar buttons
- highlight selected template and smooth color transitions

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run build` (fails: Property 'setPageBreak' does not exist on type 'ChainedCommands')

------
https://chatgpt.com/codex/tasks/task_e_688e154cde44832480b4312eed236425