### PR TITLE
Fix ProseMirror styling warning by importing default CSS

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,10 @@
 @tailwind components;
 @tailwind utilities;
 
+.ProseMirror {
+  white-space: pre-wrap;
+}
+
 .page {
   background: white;
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,6 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import 'prosemirror-view/style/prosemirror.css'
 import './index.css'
 import App from './App.tsx'
 


### PR DESCRIPTION
## Summary
- Import ProseMirror's default styles to satisfy editor CSS requirements
- Ensure `.ProseMirror` white-space is set to `pre-wrap` in global stylesheet

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688e2081fcf483248d48a2e93ed4a695