### PR TITLE
style: enhance template sidebar design

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,31 @@
+import { forwardRef, type ButtonHTMLAttributes } from 'react'
+import { cn } from '../../lib/utils'
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'default' | 'secondary' | 'ghost'
+  asChild?: boolean
+}
+
+/** Simplified shadcn/ui style button */
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant = 'default', ...props }, ref) => {
+    const base = 'inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none'
+    const variants: Record<NonNullable<ButtonProps['variant']>, string> = {
+      default: 'bg-blue-600 text-white hover:bg-blue-500',
+      secondary: 'bg-gray-200 text-gray-900 hover:bg-gray-300',
+      ghost: 'hover:bg-gray-100 text-gray-900',
+    }
+
+    return (
+      <button
+        ref={ref}
+        className={cn(base, variants[variant], className)}
+        {...props}
+      />
+    )
+  }
+)
+
+Button.displayName = 'Button'
+
+export default Button

--- a/src/editor/components/TemplateSidebar.tsx
+++ b/src/editor/components/TemplateSidebar.tsx
@@ -1,5 +1,7 @@
 import { Editor } from '@tiptap/react'
-import { useState } from 'react'
+import { motion } from 'framer-motion'
+import { useRef, useState } from 'react'
+import { Button } from '../../components/ui/button'
 
 const templates = [
   {
@@ -21,28 +23,51 @@ const templates = [
 
 export const TemplateSidebar = ({ editor }: { editor: Editor | null }) => {
   const [active, setActive] = useState<string | null>(null)
+  const itemRefs = useRef<(HTMLButtonElement | null)[]>([])
+
+  const handleSelect = (t: { name: string; content: string }) => {
+    editor?.commands.insertContent(t.content)
+    setActive(t.name)
+  }
+
+  const MotionButton = motion(Button)
 
   return (
-    <div className="w-60 border-l p-2 space-y-2 overflow-y-auto">
-      {templates.map((t) => {
-        const isActive = active === t.name
-
-        return (
-          <button
-            key={t.name}
-            className={`w-full text-left border p-2 rounded transition-colors ${
-              isActive ? 'bg-gray-200' : 'bg-white hover:bg-gray-50'
-            }`}
-            onClick={() => {
-              editor?.commands.insertContent(t.content)
-              setActive(t.name)
+    <motion.aside
+      initial={{ x: 80, opacity: 0 }}
+      animate={{ x: 0, opacity: 1 }}
+      className="w-full sm:w-64 border-l bg-white p-4 space-y-2 overflow-y-auto"
+      role="listbox"
+      aria-label="Insert template"
+    >
+      {templates.map((t, i) => (
+        <motion.div
+          key={t.name}
+          initial={{ opacity: 0, y: 10 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: i * 0.05 }}
+        >
+          <MotionButton
+            ref={(el) => {
+              itemRefs.current[i] = el
+            }}
+            role="option"
+            aria-selected={active === t.name}
+            variant={active === t.name ? 'secondary' : 'ghost'}
+            className="w-full justify-start"
+            whileHover={{ scale: 1.02 }}
+            whileTap={{ scale: 0.98 }}
+            onClick={() => handleSelect(t)}
+            onKeyDown={(e) => {
+              if (e.key === 'ArrowDown') itemRefs.current[i + 1]?.focus()
+              if (e.key === 'ArrowUp') itemRefs.current[i - 1]?.focus()
             }}
           >
             {t.name}
-          </button>
-        )
-      })}
-    </div>
+          </MotionButton>
+        </motion.div>
+      ))}
+    </motion.aside>
   )
 }
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,3 @@
+export function cn(...classes: (string | undefined | false | null)[]) {
+  return classes.filter(Boolean).join(' ')
+}


### PR DESCRIPTION
## Summary
- improve TemplateSidebar with motion animations, responsive layout, and accessible keyboard navigation
- introduce reusable shadcn-style Button component and simple `cn` utility

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Property 'setPageBreak' does not exist & PageBreak type mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_688e32b100408324ba77e063eb5a26f2