### PR TITLE
Fix AI suggestion workflow and page break commands

### DIFF
--- a/src/editor/components/AISuggestion.tsx
+++ b/src/editor/components/AISuggestion.tsx
@@ -10,6 +10,7 @@ export const AISuggestion = ({ editor }: { editor: Editor | null }) => {
     const update = () => {
       const { from, to } = editor.state.selection
       setSelectionActive(from !== to)
+      setSuggestion('')
     }
     editor.on('selectionUpdate', update)
     return () => {

--- a/src/editor/extensions/PageBreak.ts
+++ b/src/editor/extensions/PageBreak.ts
@@ -14,11 +14,9 @@ export const PageBreak = Node.create({
     return {
       setPageBreak:
         () =>
-        ({
-          commands,
-        }: {
-          commands: { insertContent: (arg: { type: string }) => void }
-        }) => commands.insertContent({ type: this.name }),
+        ({ commands }) => {
+          return commands.insertContent({ type: this.name })
+        },
     }
   },
   parseHTML() {
@@ -32,5 +30,13 @@ export const PageBreak = Node.create({
     return ['div', { 'data-type': 'page-break', class: 'page-break' }]
   },
 })
+
+declare module '@tiptap/core' {
+  interface Commands<ReturnType> {
+    pageBreak: {
+      setPageBreak: () => ReturnType
+    }
+  }
+}
 
 export default PageBreak


### PR DESCRIPTION
## Summary
- reset AI suggestion when changing selection
- properly register page break command for Tiptap and expose typings

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688f22a901548324add2fe30e95e5983