### PR TITLE
feat: add reactive pagination and page break styling

### DIFF
--- a/src/editor/Editor.tsx
+++ b/src/editor/Editor.tsx
@@ -17,7 +17,7 @@ export const Editor = () => {
     content: '<p></p>',
   })
 
-  const pages = usePagination(editor?.getHTML() || '')
+  const pages = usePagination(editor)
   const previewRef = useRef<HTMLDivElement>(null)
 
   const handleExport = async () => {

--- a/src/editor/usePagination.ts
+++ b/src/editor/usePagination.ts
@@ -1,17 +1,31 @@
 import { useEffect, useState } from 'react'
+import type { Editor } from '@tiptap/react'
 
 /**
- * Very small pagination helper that splits raw HTML by the page break node.
+ * Paginate editor content by splitting the editor's HTML on page break nodes.
+ * The hook listens to editor updates so pagination stays in sync as the user edits.
  * A more sophisticated implementation could additionally measure content height
  * and insert automatic breaks based on page size.
  */
-export function usePagination(html: string) {
+export function usePagination(editor: Editor | null) {
   const [pages, setPages] = useState<string[]>([])
 
   useEffect(() => {
-    const parts = html.split(/<div data-type="page-break"[^>]*><\/div>/g)
-    setPages(parts)
-  }, [html])
+    if (!editor) return
+
+    const updatePages = () => {
+      const html = editor.getHTML()
+      const parts = html.split(/<div data-type="page-break"[^>]*><\/div>/g)
+      setPages(parts)
+    }
+
+    editor.on('update', updatePages)
+    updatePages()
+
+    return () => {
+      editor.off('update', updatePages)
+    }
+  }, [editor])
 
   return pages
 }

--- a/src/index.css
+++ b/src/index.css
@@ -13,4 +13,6 @@
 .page-break {
   border-top: 2px dashed #bbb;
   margin: 1rem 0;
+  break-after: page;
+  page-break-after: always;
 }


### PR DESCRIPTION
## Summary
- keep preview pages synced with editor content by listening to updates
- style page breaks with CSS to enforce page-level separation

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688f2f6244548324b234be4f45f69c7e