### PR TITLE
fix: add spacing below page header

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -252,6 +252,8 @@
   border-bottom: 1px solid #d1d5db;
   background-color: #f9fafb;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+  /* Add space below header to prevent overlap with page content */
+  margin-bottom: 16px;
 }
 
 .page-header .left {


### PR DESCRIPTION
## Summary
- add margin under page header to keep document content from overlapping

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688fa99ff5b88324afb4588faba8feed