### PR TITLE
Align editor and preview widths to prevent overflow

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -5,6 +5,7 @@
   --background-color: #f9fafb;
   --text-color: #1f2937;
   --transition-speed: 0.3s;
+  --editor-width: 794px;
 }
 
 html {

--- a/src/index.css
+++ b/src/index.css
@@ -57,7 +57,18 @@
   padding: 10px;
   background-color: white;
   border-radius: 4px;
-  margin-bottom: 20px;
+  margin: 0 auto 20px;
+  width: 100%;
+  max-width: var(--editor-width);
+  box-sizing: border-box;
+}
+
+.preview {
+  width: 100%;
+  max-width: var(--editor-width);
+  margin: 0 auto;
+  box-sizing: border-box;
+  overflow-x: hidden;
 }
 
 .page {
@@ -66,8 +77,9 @@
   border-radius: 6px;
   padding: 32px;
   margin: 20px auto;
-  width: 794px;
+  width: 100%;
   min-height: 1122px;
+  box-sizing: border-box;
 }
 
 /* Outline Panel */


### PR DESCRIPTION
## Summary
- centralize editor width with new `--editor-width` CSS variable
- constrain editor area and preview to shared width with border-box sizing to stop overflow

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688fac8cfe0c83249f034fb4bdf1d755